### PR TITLE
💰 Wallet service layer — credit, debit, unlock gate

### DIFF
--- a/backend/apps/payments/services.py
+++ b/backend/apps/payments/services.py
@@ -1,0 +1,133 @@
+import logging
+from decimal import Decimal
+
+from django.conf import settings
+from django.db import transaction
+
+from apps.payments.models import PricingPlan, Transaction, TransactionType, Wallet
+
+logger = logging.getLogger(__name__)
+
+
+class InsufficientBalanceError(Exception):
+    """Raised when a debit would push balance below the allowed debt threshold."""
+    pass
+
+
+class WalletNotFoundError(Exception):
+    pass
+
+
+def get_active_pricing_plan() -> PricingPlan:
+    """Return the currently active pricing plan. Raises if none is configured."""
+    plan = PricingPlan.objects.filter(is_active=True).first()
+    if plan is None:
+        raise ValueError("No active pricing plan configured.")
+    return plan
+
+
+def get_or_create_wallet(user) -> Wallet:
+    wallet, _ = Wallet.objects.get_or_create(user=user)
+    return wallet
+
+
+def credit_wallet(
+    wallet: Wallet,
+    amount: Decimal,
+    transaction_type: str,
+    reference: str = "",
+    pricing_plan: PricingPlan = None,
+) -> Transaction:
+    """
+    Add funds to a wallet. amount must be positive.
+    Returns the created Transaction. Runs inside a select_for_update lock.
+    """
+    if amount <= 0:
+        raise ValueError(f"Credit amount must be positive, got {amount}")
+
+    with transaction.atomic():
+        wallet = Wallet.objects.select_for_update().get(pk=wallet.pk)
+        wallet.balance += amount
+        wallet.save(update_fields=["balance", "updated_at"])
+
+        tx = Transaction.objects.create(
+            wallet=wallet,
+            type=transaction_type,
+            amount=amount,
+            balance_after=wallet.balance,
+            reference=reference,
+            pricing_plan=pricing_plan,
+        )
+
+    logger.info(
+        f"Wallet {wallet.pk} credited {amount} ({transaction_type}) "
+        f"— balance_after={wallet.balance} ref={reference}"
+    )
+    return tx
+
+
+def debit_wallet(
+    wallet: Wallet,
+    amount: Decimal,
+    transaction_type: str,
+    reference: str = "",
+    pricing_plan: PricingPlan = None,
+) -> Transaction:
+    """
+    Deduct funds from a wallet. amount must be positive (stored as negative in ledger).
+    Raises InsufficientBalanceError if the resulting balance would hit or exceed
+    the debt threshold defined in settings.DEBT_THRESHOLD.
+    Returns the created Transaction. Runs inside a select_for_update lock.
+    """
+    if amount <= 0:
+        raise ValueError(f"Debit amount must be positive, got {amount}")
+
+    debt_threshold = Decimal(str(settings.DEBT_THRESHOLD))
+
+    with transaction.atomic():
+        wallet = Wallet.objects.select_for_update().get(pk=wallet.pk)
+        new_balance = wallet.balance - amount
+
+        if new_balance <= -debt_threshold:
+            raise InsufficientBalanceError(
+                f"Debit of {amount} would bring balance to {new_balance}, "
+                f"which hits or exceeds the debt threshold of {debt_threshold}."
+            )
+
+        wallet.balance = new_balance
+        wallet.save(update_fields=["balance", "updated_at"])
+
+        tx = Transaction.objects.create(
+            wallet=wallet,
+            type=transaction_type,
+            amount=-amount,  # negative in ledger
+            balance_after=wallet.balance,
+            reference=reference,
+            pricing_plan=pricing_plan,
+        )
+
+    logger.info(
+        f"Wallet {wallet.pk} debited {amount} ({transaction_type}) "
+        f"— balance_after={wallet.balance} ref={reference}"
+    )
+    return tx
+
+
+def can_unlock(wallet: Wallet, pricing_plan: PricingPlan) -> tuple[bool, str]:
+    """
+    Check if a user is allowed to unlock a bike.
+    Returns (True, "") if allowed, or (False, reason_code) if not.
+
+    Rules:
+    - Balance must be >= -DEBT_THRESHOLD (debt below threshold rolls silently)
+    - Balance must be >= minimum_balance set in the pricing plan
+    """
+    debt_threshold = Decimal(str(settings.DEBT_THRESHOLD))
+
+    if wallet.balance <= -debt_threshold:
+        return False, "DEBT_THRESHOLD_EXCEEDED"
+
+    if wallet.balance < pricing_plan.minimum_balance:
+        return False, "INSUFFICIENT_BALANCE"
+
+    return True, ""

--- a/backend/bikeshare/settings/base.py
+++ b/backend/bikeshare/settings/base.py
@@ -102,6 +102,9 @@ SIMPLE_JWT = {
     "USER_ID_CLAIM": "user_id",
 }
 
+# Payments
+DEBT_THRESHOLD = 500  # ETB — debt at or above this amount blocks unlock
+
 # MQTT / IoT
 COMMAND_TTL_SECONDS = 10
 # MQTT_BROKER_TYPE, MQTT_BROKER_HOST, MQTT_BROKER_PORT are defined per environment


### PR DESCRIPTION
## Summary
- Adds `apps/payments/services.py` with the core wallet business logic
- Adds `DEBT_THRESHOLD = 500` (ETB) to `base.py` settings

## What's in the service layer

**`credit_wallet()`** — adds funds to a wallet. Uses `select_for_update` to lock the wallet row, updates balance atomically, appends an immutable `Transaction` record with `balance_after` snapshot.

**`debit_wallet()`** — deducts funds. Same locking pattern. Raises `InsufficientBalanceError` if the resulting balance would hit or exceed `-DEBT_THRESHOLD`. Amount stored as negative in the ledger.

**`can_unlock()`** — called before every unlock attempt. Returns `(True, "")` or `(False, reason_code)`. Two failure cases:
- `DEBT_THRESHOLD_EXCEEDED` — debt is at or above 500 ETB, blocks unlock
- `INSUFFICIENT_BALANCE` — balance below the pricing plan's `minimum_balance`

**`get_active_pricing_plan()`** — fetches the single active `PricingPlan`, raises if none configured.

**`get_or_create_wallet()`** — ensures every user has a wallet (called on first use).

## Design notes
- All balance mutations are wrapped in `select_for_update` + `transaction.atomic()` to prevent race conditions (two simultaneous unlocks depleting the same wallet)
- `debit_wallet` stores `-amount` in the ledger (negative = debit, consistent with model docstring)
- Debt threshold logic: balance can go negative freely below 500 ETB; at or above 500 ETB debt blocks unlock

Closes #15