### PR TITLE
🔌 Chapa integration — initiate top-up, webhook handler, idempotent wallet credit

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,11 @@ MQTT_BROKER_TYPE=local
 MQTT_BROKER_HOST=localhost
 MQTT_BROKER_PORT=1883
 
+# Chapa payments (required in production)
+# Get these from your Chapa dashboard → Settings → API Keys / Webhooks
+CHAPA_SECRET_KEY=
+CHAPA_WEBHOOK_SECRET=
+
 # --- Production only (DJANGO_SETTINGS_MODULE=bikeshare.settings.production) ---
 # All of these are REQUIRED in production — the server will refuse to start without them.
 # DJANGO_SETTINGS_MODULE=bikeshare.settings.production

--- a/backend/apps/payments/chapa.py
+++ b/backend/apps/payments/chapa.py
@@ -1,0 +1,108 @@
+import logging
+from decimal import Decimal
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+CHAPA_API_URL = settings.CHAPA_API_URL
+
+
+class ChapaError(Exception):
+    """Raised when the Chapa API returns an error or is unreachable."""
+    pass
+
+
+def _headers() -> dict:
+    return {
+        "Authorization": f"Bearer {settings.CHAPA_SECRET_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+def initialize_payment(
+    tx_ref: str,
+    amount: Decimal,
+    phone: str,
+    callback_url: str,
+    return_url: str,
+) -> str:
+    """
+    Initialize a Chapa payment. Returns the checkout_url.
+    Raises ChapaError on failure.
+
+    Args:
+        tx_ref: Unique transaction reference (we use TopUp UUID).
+        amount: Amount in ETB.
+        phone: User's phone number (for pre-filling Chapa's form).
+        callback_url: URL Chapa will POST to when payment completes (our webhook).
+        return_url: URL Chapa redirects the user to after payment (deep link into app).
+    """
+    payload = {
+        "amount": str(amount),
+        "currency": "ETB",
+        "tx_ref": tx_ref,
+        "callback_url": callback_url,
+        "return_url": return_url,
+        "customization": {
+            "title": "Bikeshare Wallet Top-Up",
+        },
+    }
+
+    # Phone is optional on Chapa's side but pre-fills the form
+    if phone:
+        payload["phone_number"] = phone
+
+    try:
+        response = requests.post(
+            f"{CHAPA_API_URL}/transaction/initialize",
+            json=payload,
+            headers=_headers(),
+            timeout=10,
+        )
+    except requests.RequestException as e:
+        logger.exception("Chapa initialize request failed for tx_ref=%s", tx_ref)
+        raise ChapaError("Could not reach Chapa API") from e
+
+    if not response.ok:
+        logger.error(
+            "Chapa initialize failed tx_ref=%s status=%s body=%s",
+            tx_ref, response.status_code, response.text,
+        )
+        raise ChapaError(f"Chapa returned {response.status_code}")
+
+    data = response.json()
+    checkout_url = data.get("data", {}).get("checkout_url")
+    if not checkout_url:
+        logger.error("Chapa response missing checkout_url tx_ref=%s body=%s", tx_ref, data)
+        raise ChapaError("Chapa response missing checkout_url")
+
+    return checkout_url
+
+
+def verify_transaction(tx_ref: str) -> bool:
+    """
+    Verify a transaction with Chapa. Returns True if payment is confirmed as 'success'.
+    Raises ChapaError if the API is unreachable.
+    """
+    try:
+        response = requests.get(
+            f"{CHAPA_API_URL}/transaction/verify/{tx_ref}",
+            headers=_headers(),
+            timeout=10,
+        )
+    except requests.RequestException as e:
+        logger.exception("Chapa verify request failed for tx_ref=%s", tx_ref)
+        raise ChapaError("Could not reach Chapa API") from e
+
+    if not response.ok:
+        logger.error(
+            "Chapa verify failed tx_ref=%s status=%s body=%s",
+            tx_ref, response.status_code, response.text,
+        )
+        return False
+
+    data = response.json()
+    status = data.get("data", {}).get("status", "")
+    return status == "success"

--- a/backend/apps/payments/serializers.py
+++ b/backend/apps/payments/serializers.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class InitiateTopUpSerializer(serializers.Serializer):
+    amount = serializers.DecimalField(max_digits=12, decimal_places=2)

--- a/backend/apps/payments/urls.py
+++ b/backend/apps/payments/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from apps.payments.views import InitiateTopUpView, chapa_webhook
+
+urlpatterns = [
+    path("topup/initiate/", InitiateTopUpView.as_view()),
+    path("webhook/chapa/", chapa_webhook),
+]

--- a/backend/apps/payments/views.py
+++ b/backend/apps/payments/views.py
@@ -1,0 +1,167 @@
+import hashlib
+import hmac
+import json
+import logging
+
+from django.conf import settings
+from django.db import transaction
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from django.http import JsonResponse
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.payments.chapa import ChapaError, initialize_payment, verify_transaction
+from apps.payments.models import TopUp, TopUpMethod, TopUpStatus, TransactionType
+from apps.payments.serializers import InitiateTopUpSerializer
+from apps.payments.services import credit_wallet, get_active_pricing_plan, get_or_create_wallet
+
+logger = logging.getLogger(__name__)
+
+
+class InitiateTopUpView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = InitiateTopUpSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error": "INVALID_REQUEST", "detail": serializer.errors}, status=400)
+
+        amount = serializer.validated_data["amount"]
+
+        try:
+            plan = get_active_pricing_plan()
+        except ValueError:
+            return Response({"error": "SERVICE_UNAVAILABLE", "detail": "No pricing plan configured."}, status=503)
+
+        if amount < plan.minimum_top_up:
+            return Response(
+                {
+                    "error": "AMOUNT_TOO_LOW",
+                    "detail": f"Minimum top-up is {plan.minimum_top_up} {plan.currency}.",
+                },
+                status=400,
+            )
+
+        wallet = get_or_create_wallet(request.user)
+
+        topup = TopUp.objects.create(
+            wallet=wallet,
+            amount=amount,
+            method=TopUpMethod.CHAPA,
+            status=TopUpStatus.PENDING,
+        )
+
+        callback_url = request.build_absolute_uri(f"/api/v1/payments/webhook/chapa/")
+        return_url = f"bikeshare://wallet/topup/complete?topup_id={topup.pk}"
+
+        try:
+            checkout_url = initialize_payment(
+                tx_ref=str(topup.pk),
+                amount=amount,
+                phone=request.user.phone,
+                callback_url=callback_url,
+                return_url=return_url,
+            )
+        except ChapaError as e:
+            topup.status = TopUpStatus.FAILED
+            topup.save(update_fields=["status", "updated_at"])
+            logger.error("Chapa init failed for topup=%s: %s", topup.pk, e)
+            return Response({"error": "PAYMENT_INIT_FAILED", "detail": "Could not reach payment provider."}, status=502)
+
+        topup.payment_url = checkout_url
+        topup.external_reference = str(topup.pk)
+        topup.save(update_fields=["payment_url", "external_reference", "updated_at"])
+
+        return Response(
+            {
+                "topup_id": str(topup.pk),
+                "amount": str(topup.amount),
+                "currency": plan.currency,
+                "payment_url": checkout_url,
+            },
+            status=201,
+        )
+
+
+@csrf_exempt
+@require_POST
+def chapa_webhook(request):
+    """
+    Chapa calls this URL when a payment completes.
+    Verifies signature, then credits the wallet if the transaction is confirmed.
+    Idempotent: safe to call multiple times for the same TopUp.
+    """
+    # 1. Verify webhook signature
+    signature = request.headers.get("Chapa-Signature", "")
+    webhook_secret = settings.CHAPA_WEBHOOK_SECRET
+
+    if webhook_secret:
+        expected = hmac.new(
+            webhook_secret.encode(),
+            request.body,
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(expected, signature):
+            logger.warning("Chapa webhook signature mismatch")
+            return JsonResponse({"error": "Invalid signature"}, status=400)
+
+    # 2. Parse payload
+    try:
+        payload = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    tx_ref = payload.get("tx_ref") or payload.get("trx_ref")
+    if not tx_ref:
+        logger.warning("Chapa webhook missing tx_ref: %s", payload)
+        return JsonResponse({"error": "Missing tx_ref"}, status=400)
+
+    # 3. Look up TopUp — select_for_update prevents concurrent double-credits
+    try:
+        with transaction.atomic():
+            topup = TopUp.objects.select_for_update().get(pk=tx_ref)
+
+            if topup.status == TopUpStatus.COMPLETED:
+                logger.info("Chapa webhook duplicate for topup=%s — ignoring", tx_ref)
+                return JsonResponse({"status": "ok"})
+
+            if topup.status == TopUpStatus.FAILED:
+                logger.warning("Chapa webhook for already-failed topup=%s — ignoring", tx_ref)
+                return JsonResponse({"status": "ok"})
+
+            # 4. Verify with Chapa before crediting
+            try:
+                confirmed = verify_transaction(tx_ref)
+            except ChapaError:
+                # Don't fail the webhook — Chapa will retry
+                return JsonResponse({"error": "Could not verify transaction"}, status=502)
+
+            if not confirmed:
+                logger.warning("Chapa verify returned non-success for tx_ref=%s", tx_ref)
+                topup.status = TopUpStatus.FAILED
+                topup.save(update_fields=["status", "updated_at"])
+                return JsonResponse({"status": "ok"})
+
+            # 5. Credit the wallet
+            credit_wallet(
+                wallet=topup.wallet,
+                amount=topup.amount,
+                transaction_type=TransactionType.TOP_UP,
+                reference=str(topup.pk),
+            )
+
+            topup.status = TopUpStatus.COMPLETED
+            topup.save(update_fields=["status", "updated_at"])
+
+            logger.info(
+                "Chapa payment completed topup=%s amount=%s wallet=%s",
+                topup.pk, topup.amount, topup.wallet_id,
+            )
+
+    except TopUp.DoesNotExist:
+        logger.warning("Chapa webhook for unknown tx_ref=%s", tx_ref)
+        return JsonResponse({"error": "TopUp not found"}, status=404)
+
+    return JsonResponse({"status": "ok"})

--- a/backend/bikeshare/settings/base.py
+++ b/backend/bikeshare/settings/base.py
@@ -104,6 +104,9 @@ SIMPLE_JWT = {
 
 # Payments
 DEBT_THRESHOLD = 500  # ETB — debt at or above this amount blocks unlock
+CHAPA_SECRET_KEY = os.environ.get("CHAPA_SECRET_KEY", "")
+CHAPA_WEBHOOK_SECRET = os.environ.get("CHAPA_WEBHOOK_SECRET", "")
+CHAPA_API_URL = "https://api.chapa.co/v1"
 
 # MQTT / IoT
 COMMAND_TTL_SECONDS = 10

--- a/backend/bikeshare/urls.py
+++ b/backend/bikeshare/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path("api/v1/stations/", include("apps.stations.urls")),
     path("api/v1/commands/", include("apps.commands.urls")),
     path("api/v1/me/", include("apps.rides.urls")),
+    path("api/v1/payments/", include("apps.payments.urls")),
     # Internal — called by Lambda only, protected by shared secret
     path("internal/station-event/", internal_station_event),
     path("internal/commands/sweep/", internal_sweep),

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -7,3 +7,4 @@ boto3==1.34.69
 pyyaml==6.0.1
 gunicorn==21.2.0
 whitenoise==6.6.0
+requests==2.32.3


### PR DESCRIPTION
## Summary
- Adds Chapa payment provider integration (initiate + webhook)
- Wires `/api/v1/payments/` URL namespace into main router
- Documents `CHAPA_SECRET_KEY` and `CHAPA_WEBHOOK_SECRET` in `.env.example`

## New endpoints

### `POST /api/v1/payments/topup/initiate/` (auth required)
Validates amount against `minimum_top_up` from active pricing plan, creates a `PENDING` TopUp, calls Chapa to get a `checkout_url`, and returns it to the app. The app opens the URL in a Chrome Custom Tab.

### `POST /api/v1/payments/webhook/chapa/` (no auth — Chapa calls this)
Called by Chapa when a payment completes. Verifies HMAC-SHA256 signature, confirms the transaction with Chapa's verify endpoint, then credits the wallet and marks the TopUp `COMPLETED`.

## Idempotency
Webhook handler locks the `TopUp` row with `select_for_update` inside `transaction.atomic()`. If status is already `COMPLETED` or `FAILED`, it returns 200 and does nothing. Safe to call multiple times.

## Files
- `apps/payments/chapa.py` — Chapa API client (`initialize_payment`, `verify_transaction`)
- `apps/payments/views.py` — `InitiateTopUpView` + `chapa_webhook`
- `apps/payments/serializers.py` — request validation
- `apps/payments/urls.py` — URL routing
- `bikeshare/urls.py` — wired in `/api/v1/payments/`
- `requirements/base.txt` — added `requests==2.32.3`
- `settings/base.py` — added `CHAPA_SECRET_KEY`, `CHAPA_WEBHOOK_SECRET`, `CHAPA_API_URL`

## Before testing
Add to your `.env`:
```
CHAPA_SECRET_KEY=your_chapa_secret_key
CHAPA_WEBHOOK_SECRET=your_chapa_webhook_secret
```

Closes #16