### PR TITLE
💸 Wire payments into ride lifecycle — unlock fee + per-minute ride charge

### DIFF
--- a/backend/apps/commands/services.py
+++ b/backend/apps/commands/services.py
@@ -115,6 +115,7 @@ def handle_unlock_result(request_id: str, status: str, reason: str = None) -> No
             command.resolved_at = now
             command.save(update_fields=["status", "resolved_at", "updated_at"])
             start_ride(command)
+            _charge_unlock_fee(command)
         else:
             command.status = CommandStatus.FAILED
             command.failure_reason = reason or ""
@@ -166,6 +167,30 @@ def sweep_timed_out_commands() -> int:
             count += 1
 
     return count
+
+
+def _charge_unlock_fee(command) -> None:
+    """
+    Debit the unlock fee from the user's wallet when a ride starts.
+    Logs and swallows errors — a billing failure must not block the ride.
+    """
+    from apps.payments.services import debit_wallet, get_active_pricing_plan, get_or_create_wallet
+
+    try:
+        plan = get_active_pricing_plan()
+        wallet = get_or_create_wallet(command.user)
+        debit_wallet(
+            wallet=wallet,
+            amount=plan.unlock_fee,
+            transaction_type="UNLOCK_FEE",
+            reference=str(command.request_id),
+            pricing_plan=plan,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to charge unlock fee for command=%s user=%s",
+            command.request_id, command.user_id,
+        )
 
 
 def _get_ttl_seconds() -> int:

--- a/backend/apps/rides/services.py
+++ b/backend/apps/rides/services.py
@@ -112,3 +112,38 @@ def end_ride_on_dock(
         f"Ride {ride.ride_id} COMPLETED — bike={bike_id} "
         f"end={end_station_id}-{end_dock_index} duration={duration}s"
     )
+
+    _charge_ride_fee(ride=ride, duration_seconds=duration)
+
+
+def _charge_ride_fee(ride, duration_seconds: int) -> None:
+    """
+    Debit the per-minute ride charge when a ride completes.
+    Rounds up to the nearest minute.
+    Logs and swallows errors — billing failure must not affect ride state.
+    """
+    from decimal import Decimal
+    from apps.payments.services import debit_wallet, get_active_pricing_plan, get_or_create_wallet
+
+    try:
+        plan = get_active_pricing_plan()
+        minutes = max(1, -(-duration_seconds // 60))  # ceiling division
+        amount = Decimal(str(plan.per_minute_rate)) * minutes
+
+        wallet = get_or_create_wallet(ride.user)
+        debit_wallet(
+            wallet=wallet,
+            amount=amount,
+            transaction_type="RIDE_CHARGE",
+            reference=str(ride.ride_id),
+            pricing_plan=plan,
+        )
+        logger.info(
+            "Ride charge: ride=%s user=%s duration=%ds minutes=%d amount=%s",
+            ride.ride_id, ride.user_id, duration_seconds, minutes, amount,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to charge ride fee for ride=%s user=%s",
+            ride.ride_id, ride.user_id,
+        )


### PR DESCRIPTION
## Summary
- Debits unlock fee from wallet when a ride starts (UNLOCK_RESULT SUCCESS)
- Debits per-minute ride charge when a ride ends (BIKE_DOCKED)

## Changes

### `apps/commands/services.py`
Added `_charge_unlock_fee()` called inside `handle_unlock_result()` after `start_ride()` succeeds. Fetches active pricing plan, debits `plan.unlock_fee` from the user's wallet with type `UNLOCK_FEE`.

### `apps/rides/services.py`
Added `_charge_ride_fee()` called at the end of `end_ride_on_dock()` after ride is saved. Calculates minutes with ceiling division (61s = 2 min, 60s = 1 min), multiplies by `plan.per_minute_rate`, debits with type `RIDE_CHARGE`.

## Design decision — swallow billing errors
Both charge functions catch all exceptions, log them, and return silently. A billing failure must never affect ride state — a missed charge is recoverable, a broken ride/dock/bike state is not.

## Test plan
- [ ] Unlock a bike → `UNLOCK_FEE` transaction appears in wallet ledger
- [ ] Dock the bike → `RIDE_CHARGE` transaction appears, amount = ceil(duration/60) × per_minute_rate
- [ ] Wallet balance reflects both deductions
- [ ] Ride still completes normally if pricing plan is missing (error logged, no exception raised)

Closes #17