### PR TITLE
🪙 Wallet API endpoints — balance, transactions, unlock gate

### DIFF
--- a/backend/apps/commands/services.py
+++ b/backend/apps/commands/services.py
@@ -25,6 +25,17 @@ def create_unlock_command(user, bike_id: str):
     """
     from apps.iot.publisher import publish_unlock_command
 
+    # Guard: wallet balance / debt
+    from apps.payments.services import can_unlock, get_active_pricing_plan, get_or_create_wallet
+    try:
+        plan = get_active_pricing_plan()
+        wallet = get_or_create_wallet(user)
+        allowed, reason = can_unlock(wallet, plan)
+        if not allowed:
+            return None, reason
+    except ValueError:
+        pass  # No pricing plan configured — allow unlock (shouldn't happen in production)
+
     # Guard: active ride
     if user.rides.filter(status="ACTIVE").exists():
         return None, "ACTIVE_RIDE_EXISTS"

--- a/backend/apps/commands/views.py
+++ b/backend/apps/commands/views.py
@@ -22,7 +22,12 @@ class UnlockCommandView(APIView):
         command, error_code = create_unlock_command(request.user, bike_id)
 
         if error_code:
-            http_status = 409 if error_code in ("ACTIVE_RIDE_EXISTS", "PENDING_COMMAND_EXISTS") else 400
+            if error_code in ("ACTIVE_RIDE_EXISTS", "PENDING_COMMAND_EXISTS"):
+                http_status = 409
+            elif error_code in ("INSUFFICIENT_BALANCE", "DEBT_THRESHOLD_EXCEEDED"):
+                http_status = 402
+            else:
+                http_status = 400
             return Response({"error": error_code}, status=http_status)
 
         return Response(CommandSerializer(command).data, status=202)

--- a/backend/apps/rides/urls.py
+++ b/backend/apps/rides/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
-from apps.rides.views import ActiveRideView, RideDetailView, RideListView
+from apps.rides.views import ActiveRideView, RideDetailView, RideListView, TransactionListView, WalletView
 
 urlpatterns = [
     path("active-ride/", ActiveRideView.as_view()),
     path("rides/", RideListView.as_view()),
     path("rides/<uuid:ride_id>/", RideDetailView.as_view()),
+    path("wallet/", WalletView.as_view()),
+    path("wallet/transactions/", TransactionListView.as_view()),
 ]

--- a/backend/apps/rides/views.py
+++ b/backend/apps/rides/views.py
@@ -2,6 +2,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.payments.models import Transaction
+from apps.payments.services import get_active_pricing_plan, get_or_create_wallet
 from apps.rides.models import Ride, RideStatus
 from apps.rides.serializers import RideSerializer
 
@@ -46,3 +48,59 @@ class RideDetailView(APIView):
             return Response({"error": "NOT_FOUND"}, status=404)
 
         return Response(RideSerializer(ride).data)
+
+
+class WalletView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        wallet = get_or_create_wallet(request.user)
+
+        try:
+            plan = get_active_pricing_plan()
+            minimum_balance = str(plan.minimum_balance)
+            currency = plan.currency
+        except ValueError:
+            minimum_balance = None
+            currency = "ETB"
+
+        recent_transactions = wallet.transactions.order_by("-created_at")[:10]
+
+        return Response({
+            "balance": str(wallet.balance),
+            "currency": currency,
+            "minimum_balance": minimum_balance,
+            "transactions": [
+                {
+                    "id": str(tx.pk),
+                    "type": tx.type,
+                    "amount": str(tx.amount),
+                    "balance_after": str(tx.balance_after),
+                    "reference": tx.reference,
+                    "created_at": tx.created_at.isoformat(),
+                }
+                for tx in recent_transactions
+            ],
+        })
+
+
+class TransactionListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        wallet = get_or_create_wallet(request.user)
+        transactions = wallet.transactions.order_by("-created_at")
+
+        return Response({
+            "transactions": [
+                {
+                    "id": str(tx.pk),
+                    "type": tx.type,
+                    "amount": str(tx.amount),
+                    "balance_after": str(tx.balance_after),
+                    "reference": tx.reference,
+                    "created_at": tx.created_at.isoformat(),
+                }
+                for tx in transactions
+            ],
+        })

--- a/docs/api_v1.md
+++ b/docs/api_v1.md
@@ -163,6 +163,8 @@ Initiate a bike unlock by bike QR code scan. Creates a `PENDING` command and pub
 - Bike must be docked (has a known dock and station)
 - User must have no `ACTIVE` ride
 - User must have no `PENDING` command
+- User wallet balance must be ≥ `minimum_balance` from active pricing plan
+- User debt must be below `DEBT_THRESHOLD` (500 ETB)
 
 **Response 202:**
 ```json
@@ -191,6 +193,8 @@ Initiate a bike unlock by bike QR code scan. Creates a `PENDING` command and pub
 | `DOCK_NOT_OCCUPIED` | 400 | Dock state is not OCCUPIED |
 | `ACTIVE_RIDE_EXISTS` | 409 | User already has an active ride |
 | `PENDING_COMMAND_EXISTS` | 409 | User already has a pending command |
+| `INSUFFICIENT_BALANCE` | 402 | Wallet balance below minimum required to unlock |
+| `DEBT_THRESHOLD_EXCEEDED` | 402 | Outstanding debt at or above 500 ETB |
 
 ---
 
@@ -303,6 +307,85 @@ Get a specific ride by ID. User must own the ride.
 | Code | HTTP | Meaning |
 |------|------|---------|
 | `NOT_FOUND` | 404 | Ride not found or not owned by user |
+
+---
+
+## Wallet
+
+### GET /api/v1/me/wallet/ **(auth)**
+
+Get current wallet balance, pricing info, and the 10 most recent transactions.
+
+**Response 200:**
+```json
+{
+  "balance": "1700.00",
+  "currency": "ETB",
+  "minimum_balance": "2000.00",
+  "transactions": [
+    {
+      "id": "1",
+      "type": "TOP_UP",
+      "amount": "2000.00",
+      "balance_after": "1700.00",
+      "reference": "abc123",
+      "created_at": "2026-03-07T10:00:00Z"
+    }
+  ]
+}
+```
+
+**Transaction type values:** `TOP_UP | UNLOCK_FEE | RIDE_CHARGE | REFUND`
+
+`amount` is positive for credits (`TOP_UP`, `REFUND`) and negative for debits (`UNLOCK_FEE`, `RIDE_CHARGE`).
+
+---
+
+### GET /api/v1/me/wallet/transactions/ **(auth)**
+
+Get full transaction history, ordered newest first.
+
+**Response 200:**
+```json
+{
+  "transactions": [...]
+}
+```
+
+Same transaction object structure as above.
+
+---
+
+## Payments
+
+### POST /api/v1/payments/topup/initiate/ **(auth)**
+
+Initiate a wallet top-up via Chapa. Returns a `payment_url` the app should open in a Chrome Custom Tab.
+
+**Request:**
+```json
+{ "amount": "200.00" }
+```
+
+`amount` must be ≥ `minimum_top_up` from the active pricing plan.
+
+**Response 201:**
+```json
+{
+  "topup_id": "550e8400-e29b-41d4-a716-446655440000",
+  "amount": "200.00",
+  "currency": "ETB",
+  "payment_url": "https://checkout.chapa.co/..."
+}
+```
+
+**Errors:**
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `AMOUNT_TOO_LOW` | 400 | Amount below minimum top-up |
+| `PAYMENT_INIT_FAILED` | 502 | Could not reach Chapa API |
+| `SERVICE_UNAVAILABLE` | 503 | No active pricing plan configured |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/me/wallet/` and `GET /api/v1/me/wallet/transactions/`
- Gates unlock on wallet balance and debt threshold
- Updates API docs

## New endpoints

### `GET /api/v1/me/wallet/`
Returns balance, currency, `minimum_balance` from active pricing plan, and last 10 transactions. Creates wallet automatically on first call (new users start at 0).

### `GET /api/v1/me/wallet/transactions/`
Full transaction history ordered newest first. Same transaction object structure.

## Unlock gate
`create_unlock_command()` now checks `can_unlock()` before all other guards. Returns:
- `INSUFFICIENT_BALANCE` (402) — balance below pricing plan's `minimum_balance`
- `DEBT_THRESHOLD_EXCEEDED` (402) — debt at or above 500 ETB

HTTP 402 (Payment Required) is the correct status for both — the client knows to send the user to the top-up screen.

## Docs
Updated `docs/api_v1.md` with:
- Wallet section with both endpoints and response shapes
- Payments section documenting `POST /api/v1/payments/topup/initiate/`
- Two new unlock error codes

## Test plan
- [ ] `GET /api/v1/me/wallet/` returns balance and transactions for authenticated user
- [ ] New user gets wallet auto-created with balance 0
- [ ] Unlock attempt with 0 balance returns 402 `INSUFFICIENT_BALANCE`
- [ ] Full transaction history appears in `/wallet/transactions/`

Closes #18